### PR TITLE
Fix a bug in the evaluation stage

### DIFF
--- a/run.py
+++ b/run.py
@@ -134,7 +134,7 @@ def run_task(agent_name, task, subprocess_list, device):
         else:
             if task.is_cross_app == "Y":
                 command = (
-                    f"python {os.path.join(os.getcwd(),'pipeline/evaluator.py')} "  # NOTE: try to fix file not found error
+                    f"python {os.path.join(os.getcwd(),'pipeline/cross_evaluator.py')} "  # NOTE: try to fix file not found error
                     f"--task_identifier {task.task_identifier} "
                     f"--result_dir {output_dir} "
                     f"--mode {args.mode} "


### PR DESCRIPTION
跨app任务在评估阶段应该调用pipeline/cross_evaluator.py 而不是 pipeline/evaluator.py